### PR TITLE
Update releases_linux.json URL

### DIFF
--- a/flutter.sh
+++ b/flutter.sh
@@ -19,7 +19,7 @@ download_flutter () {
   fi
   mkdir -p $SNAP_USER_COMMON
   cd $SNAP_USER_COMMON
-  curl -o releases_linux.json $FLUTTER_STORAGE_BASE_URL/flutter_infra/releases/releases_linux.json
+  curl -o releases_linux.json $FLUTTER_STORAGE_BASE_URL/flutter_infra_release/releases/releases_linux.json
   base_url=$(cat releases_linux.json | jq -r '.base_url')
   stable=$(cat releases_linux.json | jq -r '.current_release' | jq '.stable')
   archive=$(cat releases_linux.json | jq -r --arg stable "$stable" '[.releases[] | select(.hash=='$stable')][0].archive')


### PR DESCRIPTION
The snap would install an old stable (2.2.1 vs. 2.5.1) because it was using an outdated `releases_linux.json` manifest.

According to caseyhillers on #hackers-infra, the file was moved to: https://storage.googleapis.com/flutter_infra_release/releases/releases_linux.json