### PR TITLE
CI: specify a timeout for the "run app" step

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -50,8 +50,8 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
-      # one at a time to avoid conflicts due to docker host mounts
-      max-parallel: 1
+      # few at a time to possibly reduce conflicts due to docker host mounts
+      max-parallel: 3
       matrix:
         image:
           - debian-stable

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -78,6 +78,7 @@ jobs:
         run: sudo ./.github/scripts/build-app.sh ${{ github.workspace }}/test/flutter_app
       - name: Run Flutter app
         run: sudo ./.github/scripts/run-app.sh
+        timeout-minutes: 15
 
   cleanup:
     needs: [build, analyze, test]


### PR DESCRIPTION
There have been occasions where the run-step got stuck for no apparent
reason, for example:

https://github.com/canonical/flutter-snap/actions/runs/1842641473

According to the output, the app ran fine but for some reason, the step
(Flutter tool?) hung after the app was closed.

Specify a timeout to avoid that the job is stuck for several hours.
15 minutes is a very generous timeout for a step that according to the
logs typically takes less than a minute.