### PR TITLE
Stage libc6-dev-i386 to be able to build for Android

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -44,6 +44,7 @@ parts:
       - libblkid-dev
       - libc6
       - libc6-dev
+      - libc6-dev-i386
       - libc-bin
       - libgcc1
       - libgcrypt20


### PR DESCRIPTION
Fixes: #73