### PR TITLE
Pass --no-same-owner to tar xf

### DIFF
--- a/flutter.sh
+++ b/flutter.sh
@@ -26,7 +26,7 @@ download_flutter () {
   url=$base_url/$archive
   echo "Downloading $url"
   curl -o latest_stable.tar.xz --user-agent 'Flutter SDK Snap' $url
-  tar xf latest_stable.tar.xz
+  tar xf latest_stable.tar.xz --no-same-owner
   [ -d "$SNAP_USER_COMMON/flutter/.git" ] && rm -f latest_stable.tar.xz releases_linux.json
   cd -
 }


### PR DESCRIPTION
This ensures that `/root/snap/common/flutter` will be owned by root
when running Flutter as root, which is common in CIs.

Fixes: #79