### PR TITLE
CI: replace Fedora 34 with 36

### DIFF
--- a/.github/docker/Dockerfile.fedora-36
+++ b/.github/docker/Dockerfile.fedora-36
@@ -1,5 +1,5 @@
 # based on https://github.com/ogra1/snapd-docker
-FROM fedora:34
+FROM fedora:36
 
 ENV container docker
 ENV PATH "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -59,8 +59,8 @@ jobs:
       matrix:
         image:
           - debian-stable
-          - fedora-34
           - fedora-35
+          - fedora-36
           - opensuse-leap
           - opensuse-tumbleweed
           - ubuntu-18.04

--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -15,8 +15,8 @@ jobs:
       matrix:
         image:
           - debian-stable
-          - fedora-34
           - fedora-35
+          - fedora-36
           - opensuse-leap
           - opensuse-tumbleweed
           - ubuntu-18.04


### PR DESCRIPTION
Fedora 34 is EOL since 2022-06-07.