### PR TITLE
Fix typo causing incorrect `LIBGL_DRIVERS_PATH`

### DIFF
--- a/env.sh
+++ b/env.sh
@@ -24,7 +24,7 @@ HOST_DRIVERS_PATH=
 CLANG_SEARCH_DIRS=$(clang++ -print-search-dirs | awk -F = '/libraries: =/{print $NF}')
 for d in ${CLANG_SEARCH_DIRS//:/$IFS}; do
     if [ -d "$d/dri" ]; then
-        HOST_DRIVERS_PATH="$HOST_DIR_DIRS:$(realpath $d/dri)"
+        HOST_DRIVERS_PATH="$HOST_DRIVERS_PATH:$(realpath $d/dri)"
     fi
 done
 SNAP_DRIVERS_PATH=$SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/dri


### PR DESCRIPTION
This loop references the nonexistent variable `HOST_DIR_DIRS` when it should be appending to `HOST_DRIVERS_PATH`. That means it sets `HOST_DRIVERS_PATH` ends up containing only the last possible directory, which does not work if that is not the correct one (for example: if it is the 32-bit directory on a 64-bit multilib system).

I have not tested that the entire snap works correctly with this fix, but I have manually tested that the loop works, and that the snap works if I manually set LIBGL_DRIVERS_PATH to include the path this fix adds.

Fixes #93