### PR TITLE
Update daily distros

### DIFF
--- a/.github/docker/Dockerfile.opensuse-leap
+++ b/.github/docker/Dockerfile.opensuse-leap
@@ -9,7 +9,7 @@ ENV SNAPPY_LAUNCHER_INSIDE_TESTS true
 
 RUN zypper update -y
 RUN zypper install -y fuse squashfs sudo systemd-sysvinit
-RUN zypper addrepo --refresh https://download.opensuse.org/repositories/system:/snappy/openSUSE_Leap_15.3 snappy
+RUN zypper addrepo --refresh https://download.opensuse.org/repositories/system:/snappy/openSUSE_Leap_15.4 snappy
 RUN zypper --gpg-auto-import-keys refresh
 RUN zypper dup --from snappy
 RUN zypper install -y snapd

--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -15,8 +15,8 @@ jobs:
       matrix:
         image:
           - debian-stable
-          - fedora-35
           - fedora-36
+          - fedora-37
           - opensuse-leap
           - opensuse-tumbleweed
           - ubuntu-18.04


### PR DESCRIPTION
Dropped fedora-35, added fedora-37 and fixed the repo URL for opensuse-leap