### PR TITLE
Attempt to keep host swrast dri first

### DIFF
--- a/env.sh
+++ b/env.sh
@@ -24,10 +24,14 @@ HOST_DRIVERS_PATH=
 CLANG_SEARCH_DIRS=$(clang++ -print-search-dirs | awk -F = '/libraries: =/{print $NF}')
 for d in ${CLANG_SEARCH_DIRS//:/$IFS}; do
     if [ -d "$d/dri" ]; then
-        HOST_DRIVERS_PATH="$HOST_DRIVERS_PATH:$(realpath $d/dri)"
+        if [[ "$d" == /snap/flutter/* ]]; then
+            SNAP_DRIVERS_PATH="$SNAP_DRIVERS_PATH:$(realpath $d/dri)"
+        else
+            HOST_DRIVERS_PATH="$HOST_DRIVERS_PATH:$(realpath $d/dri)"
+        fi
     fi
 done
-SNAP_DRIVERS_PATH=$SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/dri
+SNAP_DRIVERS_PATH="$SNAP_DRIVERS_PATH:$SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/dri"
 export LIBGL_DRIVERS_PATH=$HOST_DRIVERS_PATH:$SNAP_DRIVERS_PATH:$LIBGL_DRIVERS_PATH
 export LIBGL_ALWAYS_SOFTWARE=1
 


### PR DESCRIPTION
Based on the `LIBGL_DRIVERS_PATH`, the original intention clearly was to have host drivers first.
```sh
export LIBGL_DRIVERS_PATH=$HOST_DRIVERS_PATH:$SNAP_DRIVERS_PATH:$LIBGL_DRIVERS_PATH
```

Also, when looking at the recently passed vs. failed CI runs, I noticed that all those that passed loaded swrast from the host, and the ones that crashed tried to load it from the snap.

The problem was that `CLANG_SEARCH_DIRS` was actually populated with snap paths first. A debug round in the CI showed:
```sh
/snap/flutter/x1/usr/lib/llvm-10/lib/clang/10.0.0:/snap/flutter/current/usr/bin/../lib/gcc/x86_64-linux-gnu/10:/snap/flutter/current/usr/bin/../lib/gcc/x86_64-linux-gnu/10/../../../x86_64-linux-gnu:/lib/x86_64-linux-gnu:/lib/../lib64:/usr/lib/x86_64-linux-gnu:/snap/flutter/current/usr/bin/../lib/gcc/x86_64-linux-gnu/10/../../..:/snap/flutter/x1/usr/lib/llvm-10/bin/../lib:/lib:/usr/lib
```

Before #94, we only picked the last Clang search dir and therefore it worked on many systems by coincidence until the typo was fixed.