### PR TITLE
Only build depend on libc6-dev-i386 for amd64

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -44,7 +44,6 @@ parts:
       - libblkid-dev
       - libc6
       - libc6-dev
-      - libc6-dev-i386
       - libc-bin
       - libcrypt1
       - libdbus-1-3
@@ -77,7 +76,7 @@ parts:
       - unzip
       - xz-utils
       - zlib1g
-      - on amd64: [ i965-va-driver ]
+      - on amd64: [ i965-va-driver, libc6-dev-i386 ]
     prime:
       - -lib32
       - -libx32


### PR DESCRIPTION
The arm64 builds are failing do to unavailability of libc6-dev-i386