### PR TITLE
Update to core24

### DIFF
--- a/env.sh
+++ b/env.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-SNAPCRAFT_ARCH_TRIPLET=<SNAPCRAFT_ARCH_TRIPLET>
+CRAFT_ARCH_TRIPLET_BUILD_FOR=<CRAFT_ARCH_TRIPLET_BUILD_FOR>
 
 SNAP=/snap/flutter/current
 SNAP_USER_COMMON=$HOME/snap/flutter/common
@@ -9,14 +9,14 @@ SNAP_USER_DATA=$HOME/snap/flutter/current
 export PATH=$SNAP/usr/bin:$SNAP/bin:$SNAP_USER_COMMON/flutter/bin:$PATH
 export GIT_EXEC_PATH=$SNAP/usr/lib/git-core
 export GIT_CONFIG_NOSYSTEM=1
-export CURL_CA_BUNDLE=/snap/core20/current/etc/ssl/certs/ca-certificates.crt
-export GIT_SSL_CAINFO=/snap/core20/current/etc/ssl/certs/ca-certificates.crt
-export CPLUS_INCLUDE_PATH=$SNAP/usr/include/$SNAPCRAFT_ARCH_TRIPLET/c++/9:$SNAP/usr/include/c++/9:$SNAP/usr/include:$SNAP/usr/include/$SNAPCRAFT_ARCH_TRIPLET:$SNAP/usr/include/c++/9
-export LIBRARY_PATH=$SNAP/usr/lib/gcc/$SNAPCRAFT_ARCH_TRIPLET/9:$SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET:$SNAP/lib/$SNAPCRAFT_ARCH_TRIPLET:$SNAP/usr/lib
+export CURL_CA_BUNDLE=/snap/core24/current/etc/ssl/certs/ca-certificates.crt
+export GIT_SSL_CAINFO=/snap/core24/current/etc/ssl/certs/ca-certificates.crt
+export CPLUS_INCLUDE_PATH=$SNAP/usr/include/$CRAFT_ARCH_TRIPLET_BUILD_FOR/c++/10:$SNAP/usr/include/c++/10:$SNAP/usr/include:$SNAP/usr/include/$CRAFT_ARCH_TRIPLET_BUILD_FOR:$SNAP/usr/include/c++/10
+export LIBRARY_PATH=$SNAP/usr/lib/gcc/$CRAFT_ARCH_TRIPLET_BUILD_FOR/10:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR:$SNAP/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR:$SNAP/usr/lib
 export LDFLAGS="-lblkid -lgcrypt -llzma -llz4 -lgpg-error -luuid -lpthread -ldl -lepoxy -lfontconfig $LDFLAGS"
-export LDFLAGS="-L$SNAP/usr/lib/gcc/$SNAPCRAFT_ARCH_TRIPLET/9 -L$SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET -L$SNAP/lib/$SNAPCRAFT_ARCH_TRIPLET -L$SNAP/usr/lib/ $LDFLAGS"
-export LDFLAGS="-B$SNAP/usr/lib/gcc/$SNAPCRAFT_ARCH_TRIPLET/9 -B$SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET -B$SNAP/lib/$SNAPCRAFT_ARCH_TRIPLET -B$SNAP/usr/lib/ $LDFLAGS"
-export PKG_CONFIG_PATH=$SNAP/usr/lib/pkgconfig:$SNAP/usr/share/pkgconfig:$SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/pkgconfig:$PKG_CONFIG_PATH:/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/pkgconfig:/usr/share/pkgconfig:/usr/lib/pkgconfig
+export LDFLAGS="-L$SNAP/usr/lib/gcc/$CRAFT_ARCH_TRIPLET_BUILD_FOR/10 -L$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR -L$SNAP/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR -L$SNAP/usr/lib/ $LDFLAGS"
+export LDFLAGS="-B$SNAP/usr/lib/gcc/$CRAFT_ARCH_TRIPLET_BUILD_FOR/10 -B$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR -B$SNAP/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR -B$SNAP/usr/lib/ $LDFLAGS"
+export PKG_CONFIG_PATH=$SNAP/usr/lib/pkgconfig:$SNAP/usr/share/pkgconfig:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/pkgconfig:$PKG_CONFIG_PATH:/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/pkgconfig:/usr/share/pkgconfig:/usr/lib/pkgconfig
 
 # find the location of DRI drivers on the host (e.g. /usr/lib/<triplet>/dri, /usr/lib64/dri, /lib64/dri, ...)
 # https://docs.mesa3d.org/faq.html#what-s-the-proper-place-for-the-libraries-and-headers
@@ -31,7 +31,7 @@ for d in ${CLANG_SEARCH_DIRS//:/$IFS}; do
         fi
     fi
 done
-SNAP_DRIVERS_PATH="$SNAP_DRIVERS_PATH:$SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/dri"
+SNAP_DRIVERS_PATH="$SNAP_DRIVERS_PATH:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/dri"
 export LIBGL_DRIVERS_PATH=$HOST_DRIVERS_PATH:$SNAP_DRIVERS_PATH:$LIBGL_DRIVERS_PATH
 export LIBGL_ALWAYS_SOFTWARE=1
 
@@ -51,9 +51,9 @@ then
 
     # Gdk-pixbuf loaders
     export GDK_PIXBUF_MODULE_FILE=$XDG_CACHE_HOME/gdk-pixbuf-loaders.cache
-    export GDK_PIXBUF_MODULEDIR=$SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/gdk-pixbuf-2.0/2.10.0/loaders
+    export GDK_PIXBUF_MODULEDIR=$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/gdk-pixbuf-2.0/2.10.0/loaders
     rm -f $GDK_PIXBUF_MODULE_FILE
-    if [ -f $SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/gdk-pixbuf-2.0/gdk-pixbuf-query-loaders ]; then
-        $SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/gdk-pixbuf-2.0/gdk-pixbuf-query-loaders > $GDK_PIXBUF_MODULE_FILE
+    if [ -f $SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/gdk-pixbuf-2.0/gdk-pixbuf-query-loaders ]; then
+        $SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/gdk-pixbuf-2.0/gdk-pixbuf-query-loaders > $GDK_PIXBUF_MODULE_FILE
     fi
 fi

--- a/flutter.sh
+++ b/flutter.sh
@@ -48,7 +48,7 @@ fi
 
 if [ ! -d "$SNAP_USER_COMMON/flutter/.git" ]; then
     echo "Initializing Flutter"
-    if [ "$SNAPCRAFT_ARCH_TRIPLET" == "aarch64-linux-gnu" ]; then
+    if [ "$CRAFT_ARCH_TRIPLET_BUILD_FOR" == "aarch64-linux-gnu" ]; then
         download_flutter_git
     else
         download_flutter

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,16 +1,20 @@
 name: flutter
-base: core20
+base: core24
 version: git
 summary: Flutter
+title: Flutter
+license: BSD-3-Clause
+source-code: https://github.com/flutter/flutter
+website: https://flutter.dev/
 description: |
   Flutter is Google’s UI toolkit for building beautiful, natively compiled
   applications for mobile, web, and desktop from a single codebase.
 
 grade: stable
 confinement: classic
-architectures:
-  - build-on: amd64
-  - build-on: arm64
+platforms:
+  amd64:
+  arm64:
 
 apps:
   flutter:
@@ -33,7 +37,7 @@ parts:
       cp flutter.desktop $SNAPCRAFT_PART_INSTALL/
 
       ENV_SH=$SNAPCRAFT_PART_INSTALL/env.sh
-      sed -i 's#<SNAPCRAFT_ARCH_TRIPLET>#$SNAPCRAFT_ARCH_TRIPLET#' $ENV_SH
+      sed -i 's#<CRAFT_ARCH_TRIPLET_BUILD_FOR>#$CRAFT_ARCH_TRIPLET_BUILD_FOR#' $ENV_SH
     stage-packages:
       - clang
       - cmake
@@ -48,9 +52,9 @@ parts:
       - libcrypt1
       - libdbus-1-3
       - libexpat1
-      - libffi7
+      - libffi8
       - libfontconfig1
-      - libjsoncpp1
+      - libjsoncpp25
       - libjsoncpp-dev
       - libgcc-s1
       - libgcrypt20
@@ -70,7 +74,7 @@ parts:
       - libsecret-1-0
       - libsecret-1-dev
       - libselinux1
-      - libsepol1
+      - libsepol2
       - libstdc++-10-dev
       - libstdc++6
       - libuuid1
@@ -105,8 +109,9 @@ parts:
       - -usr/share/icons
       - -usr/share/pixmaps
       - -usr/share/rsync
-
-
+    build-attributes:
+      - enable-patchelf
+  
   # Fix pkgconfig files
   pkgconfig:
     after: [flutter]
@@ -140,11 +145,94 @@ parts:
 
       find . -type l -name "*.so*" -exec bash -c 'if [[ $(readlink $1) == /* ]] && [[ $(readlink $1) != /snap* ]]; then ln -sf /snap/flutter/current$(readlink $1) $1; fi' bash {} \;
 
-      for so in usr/lib/$SNAPCRAFT_ARCH_TRIPLET/libc.so usr/lib/$SNAPCRAFT_ARCH_TRIPLET/libpthread.so usr/lib/$SNAPCRAFT_ARCH_TRIPLET/libm.so
+      for so in usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libc.so usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libpthread.so usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libm.so
       do
         if [ -f $SNAPCRAFT_PRIME/$so ]; then
           sed -i "$SNAPCRAFT_PRIME/${so}" \
-              -e "s# /lib/$SNAPCRAFT_ARCH_TRIPLET# /snap/$SNAPCRAFT_PROJECT_NAME/current/lib/$SNAPCRAFT_ARCH_TRIPLET#g" \
-              -e "s# \(/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/.*\)# /snap/$SNAPCRAFT_PROJECT_NAME/current\1#g"
+              -e "s# /lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR# /snap/$SNAPCRAFT_PROJECT_NAME/current/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR#g" \
+              -e "s# \(/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/.*\)# /snap/$SNAPCRAFT_PROJECT_NAME/current\1#g"
         fi
       done
+
+lint:
+  ignore:
+    - library:
+      - usr/lib/llvm-18/lib/libLTO.so.18.1
+      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libBrokenLocale.so.1
+      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libEGL.so.1.1.0
+      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libEGL_mesa.so.0.0.0
+      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libGL.so.1.7.0
+      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libGLESv1_CM.so.1.2.0
+      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libGLESv2.so.2.1.0
+      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libGLU.so.1.3.1
+      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libGLX_mesa.so.0.0.0
+      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libSM.so.6.0.1
+      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libXtst.so.6.1.0
+      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libanl.so.1
+      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libasan.so.6.0.0
+      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libasan.so.8.0.0
+      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libatomic.so.1.2.0
+      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libc_malloc_debug.so.0
+      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libcairo-script-interpreter.so.2.11800.0
+      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libclang-18.so.18
+      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libcolordprivate.so.2.0.5
+      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libdconf.so.1.0.0
+      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libdl.so.2
+      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libexpatw.so.1.9.1
+      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libgccpp.so.1.5.0
+      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libgctba.so.1.5.0
+      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libgdbm_compat.so.4.0.0
+      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libgomp.so.1.0.0
+      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libharfbuzz-cairo.so.0.60830.0
+      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libharfbuzz-gobject.so.0.60830.0
+      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libharfbuzz-icu.so.0.60830.0
+      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libharfbuzz-subset.so.0.60830.0
+      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libhwasan.so.0.0.0
+      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libicutest.so.74.2
+      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libitm.so.1.0.0
+      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/liblsan.so.0.0.0
+      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libmemusage.so
+      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libmvec.so.1
+      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libnsl.so.1
+      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libnss_compat.so.2
+      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libnss_dns.so.2
+      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libnss_files.so.2
+      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libnss_hesiod.so.2
+      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libobjc.so.4.0.0
+      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libobjc_gc.so.4.0.0
+      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libpcprofile.so
+      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libpcre2-16.so.0.11.2
+      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libpcre2-32.so.0.11.2
+      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libpcre2-posix.so.3.0.4
+      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libpcreposix.so.3.13.3
+      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libpthread.so.0
+      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libquadmath.so.0.0.0
+      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/librt.so.1
+      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libsecret-1.so.0.0.0
+      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libsepol.so.2
+      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libthread_db.so.1
+      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libtiffxx.so.6.0.1
+      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libtsan.so.0.0.0
+      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libtsan.so.2.0.0
+      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libubsan.so.1.0.0
+      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libutil.so.1
+      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libva.so.2.2000.0
+      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libvulkan.so.1.3.275
+      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libwayland-server.so.0.22.0
+      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libwebpdecoder.so.3.1.8
+      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libwebpdemux.so.2.0.14
+      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libwebpmux.so.3.0.13
+      - lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libpcre.so.3.13.3
+      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libGLX.so.0.0.0
+      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libICE.so.6.3.0
+      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libOpenGL.so.0.0.0
+      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libXxf86vm.so.1.0.0
+      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libgc.so.1.5.3
+      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libgdbm.so.6.0.0
+      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libuuid.so.1.3.0
+      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libxcb-glx.so.0.0.0
+      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libGLdispatch.so.0.0.0
+    - metadata:
+      - contact
+      - donation
+      - issues


### PR DESCRIPTION
- Updated metadata
- Change architectures to platform syntax
- Replaced deprecated SNAPCRAFT_ARCH_TRIPLET by CRAFT_ARCH_TRIPLET_BUILD_FOR
- Updated libraries
- Added linter rules for unused libraries and metadata missing