### PR TITLE
 Fix cross-distro test CI

### DIFF
--- a/.github/docker/Dockerfile.debian-stable
+++ b/.github/docker/Dockerfile.debian-stable
@@ -18,7 +18,7 @@ VOLUME ["/sys/fs/cgroup"]
 STOPSIGNAL SIGRTMIN+3
 CMD ["/sbin/init"]
 
-RUN DEBIAN_FRONTEND=noninteractive apt-get install -y libgtk-3-0 libegl1 xvfb
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y libgtk-3-0 libegl1 libgles2 xvfb
 
 # https://github.com/diddlesnaps/snapcraft-container/pull/17
 RUN dpkg-divert --local --rename --add /usr/bin/systemd-detect-virt

--- a/.github/docker/Dockerfile.fedora-42
+++ b/.github/docker/Dockerfile.fedora-42
@@ -9,7 +9,7 @@ ENV SNAPPY_LAUNCHER_INSIDE_TESTS=true
 
 RUN dnf upgrade -y
 RUN dnf install -y fuse snapd squashfuse sudo
-RUN dnf install -y gtk3 mesa-dri-drivers mesa-libEGL xorg-x11-server-Xvfb
+RUN dnf install -y gtk3 mesa-dri-drivers mesa-libEGL mesa-libGLES xorg-x11-server-Xvfb
 
 RUN ln -sf /bin/true /sbin/udevadm
 RUN ln -s /var/lib/snapd/snap /snap

--- a/.github/docker/Dockerfile.opensuse-leap
+++ b/.github/docker/Dockerfile.opensuse-leap
@@ -8,12 +8,12 @@ ENV LC_ALL=C.UTF-8
 ENV SNAPPY_LAUNCHER_INSIDE_TESTS=true
 
 RUN zypper update -y
-RUN zypper install -y fuse squashfs sudo systemd-sysvinit
-RUN zypper addrepo --refresh https://download.opensuse.org/repositories/system:/snappy/openSUSE_Leap_15.6 snappy
+RUN zypper install -y fuse squashfs sudo systemd
+RUN zypper addrepo --refresh https://download.opensuse.org/repositories/system:/snappy/openSUSE_Leap_16.0 snappy
 RUN zypper --gpg-auto-import-keys refresh
 RUN zypper dup --from snappy
 RUN zypper install -y snapd
-RUN zypper install -y gtk3 Mesa-libEGL1 xvfb-run
+RUN zypper install -y gtk3 Mesa-libEGL1 Mesa-libGLESv2-2 xvfb-run
 RUN zypper install -y tar which
 
 RUN ln -sf /bin/true /sbin/udevadm

--- a/.github/docker/Dockerfile.opensuse-tumbleweed
+++ b/.github/docker/Dockerfile.opensuse-tumbleweed
@@ -8,12 +8,12 @@ ENV LC_ALL=C.UTF-8
 ENV SNAPPY_LAUNCHER_INSIDE_TESTS=true
 
 RUN zypper update -y
-RUN zypper install -y fuse squashfs sudo systemd-sysvinit
+RUN zypper install -y fuse squashfs sudo systemd
 RUN zypper addrepo --refresh https://download.opensuse.org/repositories/system:/snappy/openSUSE_Tumbleweed snappy
 RUN zypper --gpg-auto-import-keys refresh
 RUN zypper dup --from snappy
 RUN zypper install -y snapd
-RUN zypper install -y gtk3 Mesa-libEGL1 xvfb-run
+RUN zypper install -y gtk3 Mesa-libEGL1 Mesa-libGLESv2-2 xvfb-run
 RUN zypper install -y tar which gawk
 
 RUN ln -sf /bin/true /sbin/udevadm

--- a/.github/docker/Dockerfile.ubuntu-22.04
+++ b/.github/docker/Dockerfile.ubuntu-22.04
@@ -18,7 +18,7 @@ VOLUME ["/sys/fs/cgroup"]
 STOPSIGNAL SIGRTMIN+3
 CMD ["/sbin/init"]
 
-RUN DEBIAN_FRONTEND=noninteractive apt-get install -y libgtk-3-0 libegl1 xvfb
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y libgtk-3-0 libegl1 libgles2 xvfb
 
 # https://github.com/diddlesnaps/snapcraft-container/pull/17
 RUN dpkg-divert --local --rename --add /usr/bin/systemd-detect-virt

--- a/.github/docker/Dockerfile.ubuntu-24.04
+++ b/.github/docker/Dockerfile.ubuntu-24.04
@@ -18,7 +18,7 @@ VOLUME ["/sys/fs/cgroup"]
 STOPSIGNAL SIGRTMIN+3
 CMD ["/sbin/init"]
 
-RUN DEBIAN_FRONTEND=noninteractive apt-get install -y libgtk-3-0 libegl1 xvfb
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y libgtk-3-0 libegl1 libgles2 xvfb
 
 # https://github.com/diddlesnaps/snapcraft-container/pull/17
 RUN dpkg-divert --local --rename --add /usr/bin/systemd-detect-virt

--- a/.github/docker/Dockerfile.ubuntu-25.10
+++ b/.github/docker/Dockerfile.ubuntu-25.10
@@ -18,7 +18,7 @@ VOLUME ["/sys/fs/cgroup"]
 STOPSIGNAL SIGRTMIN+3
 CMD ["/sbin/init"]
 
-RUN DEBIAN_FRONTEND=noninteractive apt-get install -y libgtk-3-0 libegl1 xvfb
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y libgtk-3-0 libegl1 libgles2 xvfb
 
 # https://github.com/diddlesnaps/snapcraft-container/pull/17
 RUN dpkg-divert --local --rename --add /usr/bin/systemd-detect-virt

--- a/.github/docker/Dockerfile.ubuntu-26.04
+++ b/.github/docker/Dockerfile.ubuntu-26.04
@@ -18,7 +18,7 @@ VOLUME ["/sys/fs/cgroup"]
 STOPSIGNAL SIGRTMIN+3
 CMD ["/sbin/init"]
 
-RUN DEBIAN_FRONTEND=noninteractive apt-get install -y libgtk-3-0 libegl1 xvfb
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y libgtk-3-0 libegl1 libgles2 xvfb
 
 # https://github.com/diddlesnaps/snapcraft-container/pull/17
 RUN dpkg-divert --local --rename --add /usr/bin/systemd-detect-virt

--- a/.github/scripts/build-image.sh
+++ b/.github/scripts/build-image.sh
@@ -18,6 +18,7 @@ docker run \
     --cap-add SYS_ADMIN \
     --device=/dev/fuse \
     --privileged \
+    --cgroupns=host \
     --security-opt apparmor:unconfined \
     --security-opt seccomp:unconfined \
     -v /sys/fs/cgroup:/sys/fs/cgroup:rw \
@@ -33,6 +34,10 @@ while [ "$(docker exec snapc sh -c 'systemctl status snapd.seeded >/dev/null 2>&
     sleep $SLEEP || exit 1
     if [ "$TIMEOUT" -le "0" ]; then
         echo " Timed out!"
+        echo "Container status:"
+        docker ps -a --filter name=snapc
+        echo "Container logs:"
+        docker logs snapc || true
         exit 1
     fi
     TIMEOUT=$(($TIMEOUT-1))

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -89,6 +89,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Delete Flutter snap
-        uses: geekyeggo/delete-artifact@v1
+        uses: geekyeggo/delete-artifact@v6
         with:
           name: snap

--- a/env.sh
+++ b/env.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-CRAFT_ARCH_TRIPLET_BUILD_FOR=<CRAFT_ARCH_TRIPLET_BUILD_FOR>
+CRAFT_ARCH_TRIPLET=<CRAFT_ARCH_TRIPLET>
 
 SNAP=/snap/flutter/current
 SNAP_USER_COMMON=$HOME/snap/flutter/common
@@ -9,14 +9,18 @@ SNAP_USER_DATA=$HOME/snap/flutter/current
 export PATH=$SNAP/usr/bin:$SNAP/bin:$SNAP_USER_COMMON/flutter/bin:$PATH
 export GIT_EXEC_PATH=$SNAP/usr/lib/git-core
 export GIT_CONFIG_NOSYSTEM=1
-export CURL_CA_BUNDLE=/snap/core24/current/etc/ssl/certs/ca-certificates.crt
-export GIT_SSL_CAINFO=/snap/core24/current/etc/ssl/certs/ca-certificates.crt
-export CPLUS_INCLUDE_PATH=$SNAP/usr/include/$CRAFT_ARCH_TRIPLET_BUILD_FOR/c++/10:$SNAP/usr/include/c++/10:$SNAP/usr/include:$SNAP/usr/include/$CRAFT_ARCH_TRIPLET_BUILD_FOR:$SNAP/usr/include/c++/10
-export LIBRARY_PATH=$SNAP/usr/lib/gcc/$CRAFT_ARCH_TRIPLET_BUILD_FOR/10:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR:$SNAP/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR:$SNAP/usr/lib
+export CURL_CA_BUNDLE=/snap/core22/current/etc/ssl/certs/ca-certificates.crt
+export GIT_SSL_CAINFO=/snap/core22/current/etc/ssl/certs/ca-certificates.crt
+export CPLUS_INCLUDE_PATH=$SNAP/usr/include/$CRAFT_ARCH_TRIPLET/c++/10:$SNAP/usr/include/c++/10:$SNAP/usr/include:$SNAP/usr/include/$CRAFT_ARCH_TRIPLET:$SNAP/usr/include/c++/10
+export LIBRARY_PATH=$SNAP/usr/lib/gcc/$CRAFT_ARCH_TRIPLET/10:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET:$SNAP/lib/$CRAFT_ARCH_TRIPLET:$SNAP/usr/lib
+# Point the linker at the snap's own libraries so builds link against them
+# rather than the host's, keeping builds self-contained and independent of
+# the host's glibc.
 export LDFLAGS="-lblkid -lgcrypt -llzma -llz4 -lgpg-error -luuid -lpthread -ldl -lepoxy -lfontconfig $LDFLAGS"
-export LDFLAGS="-L$SNAP/usr/lib/gcc/$CRAFT_ARCH_TRIPLET_BUILD_FOR/10 -L$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR -L$SNAP/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR -L$SNAP/usr/lib/ $LDFLAGS"
-export LDFLAGS="-B$SNAP/usr/lib/gcc/$CRAFT_ARCH_TRIPLET_BUILD_FOR/10 -B$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR -B$SNAP/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR -B$SNAP/usr/lib/ $LDFLAGS"
-export PKG_CONFIG_PATH=$SNAP/usr/lib/pkgconfig:$SNAP/usr/share/pkgconfig:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/pkgconfig:$PKG_CONFIG_PATH:/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/pkgconfig:/usr/share/pkgconfig:/usr/lib/pkgconfig
+export LDFLAGS="-L$SNAP/usr/lib/gcc/$CRAFT_ARCH_TRIPLET/10 -L$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET -L$SNAP/lib/$CRAFT_ARCH_TRIPLET -L$SNAP/usr/lib/ $LDFLAGS"
+export LDFLAGS="-Wl,-rpath-link=$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET:$SNAP/lib/$CRAFT_ARCH_TRIPLET:/snap/core22/current/usr/lib/$CRAFT_ARCH_TRIPLET:/snap/core22/current/lib/$CRAFT_ARCH_TRIPLET $LDFLAGS"
+export LDFLAGS="-B$SNAP/usr/lib/gcc/$CRAFT_ARCH_TRIPLET/10 -B$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET -B$SNAP/lib/$CRAFT_ARCH_TRIPLET -B$SNAP/usr/lib/ $LDFLAGS"
+export PKG_CONFIG_PATH=$SNAP/usr/lib/pkgconfig:$SNAP/usr/share/pkgconfig:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET/pkgconfig:$PKG_CONFIG_PATH:/usr/lib/$CRAFT_ARCH_TRIPLET/pkgconfig:/usr/share/pkgconfig:/usr/lib/pkgconfig
 
 # find the location of DRI drivers on the host (e.g. /usr/lib/<triplet>/dri, /usr/lib64/dri, /lib64/dri, ...)
 # https://docs.mesa3d.org/faq.html#what-s-the-proper-place-for-the-libraries-and-headers
@@ -31,7 +35,7 @@ for d in ${CLANG_SEARCH_DIRS//:/$IFS}; do
         fi
     fi
 done
-SNAP_DRIVERS_PATH="$SNAP_DRIVERS_PATH:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/dri"
+SNAP_DRIVERS_PATH="$SNAP_DRIVERS_PATH:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET/dri"
 export LIBGL_DRIVERS_PATH=$HOST_DRIVERS_PATH:$SNAP_DRIVERS_PATH:$LIBGL_DRIVERS_PATH
 export LIBGL_ALWAYS_SOFTWARE=1
 
@@ -51,9 +55,9 @@ then
 
     # Gdk-pixbuf loaders
     export GDK_PIXBUF_MODULE_FILE=$XDG_CACHE_HOME/gdk-pixbuf-loaders.cache
-    export GDK_PIXBUF_MODULEDIR=$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/gdk-pixbuf-2.0/2.10.0/loaders
+    export GDK_PIXBUF_MODULEDIR=$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET/gdk-pixbuf-2.0/2.10.0/loaders
     rm -f $GDK_PIXBUF_MODULE_FILE
-    if [ -f $SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/gdk-pixbuf-2.0/gdk-pixbuf-query-loaders ]; then
-        $SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/gdk-pixbuf-2.0/gdk-pixbuf-query-loaders > $GDK_PIXBUF_MODULE_FILE
+    if [ -f $SNAP/usr/lib/$CRAFT_ARCH_TRIPLET/gdk-pixbuf-2.0/gdk-pixbuf-query-loaders ]; then
+        $SNAP/usr/lib/$CRAFT_ARCH_TRIPLET/gdk-pixbuf-2.0/gdk-pixbuf-query-loaders > $GDK_PIXBUF_MODULE_FILE
     fi
 fi

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: flutter
-base: core24
+base: core22
 version: git
 summary: Flutter
 title: Flutter
@@ -12,9 +12,9 @@ description: |
 
 grade: stable
 confinement: classic
-platforms:
-  amd64:
-  arm64:
+architectures:
+  - build-on: amd64
+  - build-on: arm64
 
 apps:
   flutter:
@@ -37,7 +37,7 @@ parts:
       cp flutter.desktop $SNAPCRAFT_PART_INSTALL/
 
       ENV_SH=$SNAPCRAFT_PART_INSTALL/env.sh
-      sed -i 's#<CRAFT_ARCH_TRIPLET_BUILD_FOR>#$CRAFT_ARCH_TRIPLET_BUILD_FOR#' $ENV_SH
+      sed -i 's#<CRAFT_ARCH_TRIPLET>#$CRAFT_ARCH_TRIPLET#' $ENV_SH
     stage-packages:
       - clang
       - cmake
@@ -46,11 +46,13 @@ parts:
       - jq
       - libblkid1
       - libblkid-dev
+      - libbsd0
       - libc6
       - libc6-dev
       - libc-bin
       - libcrypt1
       - libdbus-1-3
+      - libedit2
       - libexpat1
       - libffi8
       - libfontconfig1
@@ -69,6 +71,7 @@ parts:
       - liblz4-dev
       - liblzma5
       - liblzma-dev
+      - libmd0
       - libmount1
       - libpcre3
       - libsecret-1-0
@@ -77,7 +80,9 @@ parts:
       - libsepol2
       - libstdc++-10-dev
       - libstdc++6
+      - libtinfo6
       - libuuid1
+      - libzstd1
       - ninja-build
       - pkg-config
       - rsync
@@ -111,7 +116,7 @@ parts:
       - -usr/share/rsync
     build-attributes:
       - enable-patchelf
-  
+
   # Fix pkgconfig files
   pkgconfig:
     after: [flutter]
@@ -136,7 +141,10 @@ parts:
         sed -i 's#/etc/#/snap/$SNAPCRAFT_PROJECT_NAME/current/etc/#g' $PC
       done
 
-  # Fix linker files
+  # Rewrite the bundled linker scripts and library symlinks to point inside
+  # the snap so the toolchain links against the snap's own libraries rather
+  # than the host's, keeping builds self-contained and independent of the
+  # host's glibc.
   linker:
     after: [flutter]
     plugin: nil
@@ -145,93 +153,115 @@ parts:
 
       find . -type l -name "*.so*" -exec bash -c 'if [[ $(readlink $1) == /* ]] && [[ $(readlink $1) != /snap* ]]; then ln -sf /snap/flutter/current$(readlink $1) $1; fi' bash {} \;
 
-      for so in usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libc.so usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libpthread.so usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libm.so
+      if [ -d lib/$CRAFT_ARCH_TRIPLET ]; then
+        for lib in lib/$CRAFT_ARCH_TRIPLET/*
+        do
+          target=usr/lib/$CRAFT_ARCH_TRIPLET/$(basename $lib)
+          if [ ! -e $target ]; then
+            ln -s /snap/$SNAPCRAFT_PROJECT_NAME/current/$lib $target
+          fi
+        done
+      fi
+
+      if [ -d lib64 ]; then
+        mkdir -p usr/lib64
+        for lib in lib64/*
+        do
+          target=usr/lib64/$(basename $lib)
+          if [ ! -e $target ]; then
+            ln -s /snap/$SNAPCRAFT_PROJECT_NAME/current/$lib $target
+          fi
+        done
+      fi
+
+      for so in usr/lib/$CRAFT_ARCH_TRIPLET/libc.so usr/lib/$CRAFT_ARCH_TRIPLET/libpthread.so usr/lib/$CRAFT_ARCH_TRIPLET/libm.so
       do
         if [ -f $SNAPCRAFT_PRIME/$so ]; then
           sed -i "$SNAPCRAFT_PRIME/${so}" \
-              -e "s# /lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR# /snap/$SNAPCRAFT_PROJECT_NAME/current/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR#g" \
-              -e "s# \(/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/.*\)# /snap/$SNAPCRAFT_PROJECT_NAME/current\1#g"
+              -e "s# /lib/$CRAFT_ARCH_TRIPLET/# /snap/$SNAPCRAFT_PROJECT_NAME/current/usr/lib/$CRAFT_ARCH_TRIPLET/#g" \
+              -e "s# /usr/lib/$CRAFT_ARCH_TRIPLET/# /snap/$SNAPCRAFT_PROJECT_NAME/current/usr/lib/$CRAFT_ARCH_TRIPLET/#g" \
+              -e "s# /lib64/# /snap/$SNAPCRAFT_PROJECT_NAME/current/usr/lib64/#g"
         fi
       done
 
 lint:
   ignore:
     - library:
-      - usr/lib/llvm-18/lib/libLTO.so.18.1
-      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libBrokenLocale.so.1
-      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libEGL.so.1.1.0
-      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libEGL_mesa.so.0.0.0
-      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libGL.so.1.7.0
-      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libGLESv1_CM.so.1.2.0
-      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libGLESv2.so.2.1.0
-      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libGLU.so.1.3.1
-      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libGLX_mesa.so.0.0.0
-      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libSM.so.6.0.1
-      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libXtst.so.6.1.0
-      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libanl.so.1
-      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libasan.so.6.0.0
-      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libasan.so.8.0.0
-      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libatomic.so.1.2.0
-      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libc_malloc_debug.so.0
-      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libcairo-script-interpreter.so.2.11800.0
-      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libclang-18.so.18
-      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libcolordprivate.so.2.0.5
-      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libdconf.so.1.0.0
-      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libdl.so.2
-      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libexpatw.so.1.9.1
-      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libgccpp.so.1.5.0
-      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libgctba.so.1.5.0
-      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libgdbm_compat.so.4.0.0
-      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libgomp.so.1.0.0
-      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libharfbuzz-cairo.so.0.60830.0
-      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libharfbuzz-gobject.so.0.60830.0
-      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libharfbuzz-icu.so.0.60830.0
-      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libharfbuzz-subset.so.0.60830.0
-      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libhwasan.so.0.0.0
-      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libicutest.so.74.2
-      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libitm.so.1.0.0
-      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/liblsan.so.0.0.0
-      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libmemusage.so
-      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libmvec.so.1
-      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libnsl.so.1
-      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libnss_compat.so.2
-      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libnss_dns.so.2
-      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libnss_files.so.2
-      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libnss_hesiod.so.2
-      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libobjc.so.4.0.0
-      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libobjc_gc.so.4.0.0
-      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libpcprofile.so
-      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libpcre2-16.so.0.11.2
-      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libpcre2-32.so.0.11.2
-      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libpcre2-posix.so.3.0.4
-      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libpcreposix.so.3.13.3
-      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libpthread.so.0
-      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libquadmath.so.0.0.0
-      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/librt.so.1
-      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libsecret-1.so.0.0.0
-      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libsepol.so.2
-      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libthread_db.so.1
-      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libtiffxx.so.6.0.1
-      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libtsan.so.0.0.0
-      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libtsan.so.2.0.0
-      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libubsan.so.1.0.0
-      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libutil.so.1
-      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libva.so.2.2000.0
-      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libvulkan.so.1.3.275
-      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libwayland-server.so.0.22.0
-      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libwebpdecoder.so.3.1.8
-      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libwebpdemux.so.2.0.14
-      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libwebpmux.so.3.0.13
-      - lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libpcre.so.3.13.3
-      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libGLX.so.0.0.0
-      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libICE.so.6.3.0
-      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libOpenGL.so.0.0.0
-      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libXxf86vm.so.1.0.0
-      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libgc.so.1.5.3
-      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libgdbm.so.6.0.0
-      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libuuid.so.1.3.0
-      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libxcb-glx.so.0.0.0
-      - usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libGLdispatch.so.0.0.0
+      - usr/lib/llvm-14/lib/libLTO.so.14
+      - usr/lib/$CRAFT_ARCH_TRIPLET/libBrokenLocale.so.1
+      - usr/lib/$CRAFT_ARCH_TRIPLET/libEGL.so.1.1.0
+      - usr/lib/$CRAFT_ARCH_TRIPLET/libEGL_mesa.so.0.0.0
+      - usr/lib/$CRAFT_ARCH_TRIPLET/libGL.so.1.7.0
+      - usr/lib/$CRAFT_ARCH_TRIPLET/libGLESv1_CM.so.1.2.0
+      - usr/lib/$CRAFT_ARCH_TRIPLET/libGLESv2.so.2.1.0
+      - usr/lib/$CRAFT_ARCH_TRIPLET/libGLU.so.1.3.1
+      - usr/lib/$CRAFT_ARCH_TRIPLET/libGLX_mesa.so.0.0.0
+      - usr/lib/$CRAFT_ARCH_TRIPLET/libSM.so.6.0.1
+      - usr/lib/$CRAFT_ARCH_TRIPLET/libXtst.so.6.1.0
+      - usr/lib/$CRAFT_ARCH_TRIPLET/libanl.so.1
+      - usr/lib/$CRAFT_ARCH_TRIPLET/libasan.so.6.0.0
+      - usr/lib/$CRAFT_ARCH_TRIPLET/libasan.so.8.0.0
+      - usr/lib/$CRAFT_ARCH_TRIPLET/libatomic.so.1.2.0
+      - usr/lib/$CRAFT_ARCH_TRIPLET/libc_malloc_debug.so.0
+      - usr/lib/$CRAFT_ARCH_TRIPLET/libcairo-script-interpreter.so.2.11800.0
+      - usr/lib/$CRAFT_ARCH_TRIPLET/libclang-14.so.14
+      - usr/lib/$CRAFT_ARCH_TRIPLET/libcolordprivate.so.2.0.5
+      - usr/lib/$CRAFT_ARCH_TRIPLET/libdconf.so.1.0.0
+      - usr/lib/$CRAFT_ARCH_TRIPLET/libdl.so.2
+      - usr/lib/$CRAFT_ARCH_TRIPLET/libexpatw.so.1.9.1
+      - usr/lib/$CRAFT_ARCH_TRIPLET/libgccpp.so.1.5.0
+      - usr/lib/$CRAFT_ARCH_TRIPLET/libgctba.so.1.5.0
+      - usr/lib/$CRAFT_ARCH_TRIPLET/libgdbm_compat.so.4.0.0
+      - usr/lib/$CRAFT_ARCH_TRIPLET/libgomp.so.1.0.0
+      - usr/lib/$CRAFT_ARCH_TRIPLET/libharfbuzz-cairo.so.0.60830.0
+      - usr/lib/$CRAFT_ARCH_TRIPLET/libharfbuzz-gobject.so.0.60830.0
+      - usr/lib/$CRAFT_ARCH_TRIPLET/libharfbuzz-icu.so.0.60830.0
+      - usr/lib/$CRAFT_ARCH_TRIPLET/libharfbuzz-subset.so.0.60830.0
+      - usr/lib/$CRAFT_ARCH_TRIPLET/libhwasan.so.0.0.0
+      - usr/lib/$CRAFT_ARCH_TRIPLET/libicutest.so.74.2
+      - usr/lib/$CRAFT_ARCH_TRIPLET/libitm.so.1.0.0
+      - usr/lib/$CRAFT_ARCH_TRIPLET/liblsan.so.0.0.0
+      - usr/lib/$CRAFT_ARCH_TRIPLET/libmemusage.so
+      - usr/lib/$CRAFT_ARCH_TRIPLET/libmvec.so.1
+      - usr/lib/$CRAFT_ARCH_TRIPLET/libnsl.so.1
+      - usr/lib/$CRAFT_ARCH_TRIPLET/libnss_compat.so.2
+      - usr/lib/$CRAFT_ARCH_TRIPLET/libnss_dns.so.2
+      - usr/lib/$CRAFT_ARCH_TRIPLET/libnss_files.so.2
+      - usr/lib/$CRAFT_ARCH_TRIPLET/libnss_hesiod.so.2
+      - usr/lib/$CRAFT_ARCH_TRIPLET/libobjc.so.4.0.0
+      - usr/lib/$CRAFT_ARCH_TRIPLET/libobjc_gc.so.4.0.0
+      - usr/lib/$CRAFT_ARCH_TRIPLET/libpcprofile.so
+      - usr/lib/$CRAFT_ARCH_TRIPLET/libpcre2-16.so.0.11.2
+      - usr/lib/$CRAFT_ARCH_TRIPLET/libpcre2-32.so.0.11.2
+      - usr/lib/$CRAFT_ARCH_TRIPLET/libpcre2-posix.so.3.0.4
+      - usr/lib/$CRAFT_ARCH_TRIPLET/libpcreposix.so.3.13.3
+      - usr/lib/$CRAFT_ARCH_TRIPLET/libpthread.so.0
+      - usr/lib/$CRAFT_ARCH_TRIPLET/libquadmath.so.0.0.0
+      - usr/lib/$CRAFT_ARCH_TRIPLET/librt.so.1
+      - usr/lib/$CRAFT_ARCH_TRIPLET/libsecret-1.so.0.0.0
+      - usr/lib/$CRAFT_ARCH_TRIPLET/libsepol.so.2
+      - usr/lib/$CRAFT_ARCH_TRIPLET/libthread_db.so.1
+      - usr/lib/$CRAFT_ARCH_TRIPLET/libtiffxx.so.6.0.1
+      - usr/lib/$CRAFT_ARCH_TRIPLET/libtsan.so.0.0.0
+      - usr/lib/$CRAFT_ARCH_TRIPLET/libtsan.so.2.0.0
+      - usr/lib/$CRAFT_ARCH_TRIPLET/libubsan.so.1.0.0
+      - usr/lib/$CRAFT_ARCH_TRIPLET/libutil.so.1
+      - usr/lib/$CRAFT_ARCH_TRIPLET/libva.so.2.2000.0
+      - usr/lib/$CRAFT_ARCH_TRIPLET/libvulkan.so.1.3.275
+      - usr/lib/$CRAFT_ARCH_TRIPLET/libwayland-server.so.0.22.0
+      - usr/lib/$CRAFT_ARCH_TRIPLET/libwebpdecoder.so.3.1.8
+      - usr/lib/$CRAFT_ARCH_TRIPLET/libwebpdemux.so.2.0.14
+      - usr/lib/$CRAFT_ARCH_TRIPLET/libwebpmux.so.3.0.13
+      - lib/$CRAFT_ARCH_TRIPLET/libpcre.so.3.13.3
+      - usr/lib/$CRAFT_ARCH_TRIPLET/libGLX.so.0.0.0
+      - usr/lib/$CRAFT_ARCH_TRIPLET/libICE.so.6.3.0
+      - usr/lib/$CRAFT_ARCH_TRIPLET/libOpenGL.so.0.0.0
+      - usr/lib/$CRAFT_ARCH_TRIPLET/libXxf86vm.so.1.0.0
+      - usr/lib/$CRAFT_ARCH_TRIPLET/libgc.so.1.5.3
+      - usr/lib/$CRAFT_ARCH_TRIPLET/libgdbm.so.6.0.0
+      - usr/lib/$CRAFT_ARCH_TRIPLET/libuuid.so.1.3.0
+      - usr/lib/$CRAFT_ARCH_TRIPLET/libxcb-glx.so.0.0.0
+      - usr/lib/$CRAFT_ARCH_TRIPLET/libGLdispatch.so.0.0.0
     - metadata:
       - contact
       - donation


### PR DESCRIPTION
Get the containerised, cross-distro app-build/run tests passing again and
make the built apps run on hosts with older glibc.

Switch the snap to core22:

- Change the base from core24 to core22 so locally-compiled native code
  (the app runner and the window_manager plugin) targets glibc 2.35
  instead of 2.39. This lets the built apps run on Ubuntu 22.04 as well
  as newer distributions (glibc is backwards compatible); on core24 they
  required GLIBC_2.38+ and failed to start on 22.04.
- Replace the core24 'platforms:' map with the core22 'architectures:'
  list and rename CRAFT_ARCH_TRIPLET_BUILD_FOR to CRAFT_ARCH_TRIPLET
  throughout snapcraft.yaml and env.sh, and point env.sh at
  /snap/core22 for the CA bundle and rpath-link paths.
- Update the clang/llvm lint ignore entries from llvm-18/libclang-18 to
  the llvm-14/libclang-14 shipped on core22.

Run the systemd test container with --cgroupns=host:

- On the current cgroup v2 runners systemd (PID 1) could not set up its
  cgroup hierarchy and exited immediately, so every 'docker exec'
  reported 'container is not running' until the snapd-startup wait timed
  out. Also dump container status/logs on timeout to aid debugging.

Make the bundled linker self-contained:

- The glibc ld scripts (libc.so, libm.so, ...) reference their real
  runtime objects (libc.so.6, libm.so.6, libmvec.so.1, ...) by absolute
  path; left unchanged the bundled linker resolves them against the
  host's glibc and fails when the host glibc differs from the snap's.
  Rewrite those references (and any absolute symlinks) to point inside
  the snap. On core22 the runtime objects and the loader are installed
  under lib/<triplet> and lib64 rather than usr/lib/<triplet>, so mirror
  them into usr/lib/<triplet> and usr/lib64 first, matching where the
  rewritten references point.
- Add -Wl,-rpath-link (snap and core22 base library dirs) to LDFLAGS.
  -L only affects direct -l lookups; the indirect DT_NEEDED dependencies
  of prebuilt shared libraries (e.g. the Flutter engine's
  libflutter_linux_gtk.so, needing libglib/libgio/libpthread/...) are
  resolved via -rpath-link. Without it the linker fell back to the
  host's /lib/<triplet>, leaking host libraries into the build.
- Bundle clang's runtime dependency closure (libbsd0, libedit2, libmd0,
  libtinfo6, libzstd1) as stage-packages. These were previously borrowed
  from Debian/Ubuntu hosts and are absent on Fedora, where clang++ failed
  to load with 'libbsd.so.0: cannot open shared object file'.

Fix the test container images:

- Install the GLESv2 runtime (libgles2 / mesa-libGLES / Mesa-libGLESv2-2)
  in every test image; without it running the app failed with
  "Couldn't open libGLESv2.so.2".
- openSUSE: install 'systemd' instead of the removed 'systemd-sysvinit'
  package (systemd now provides /sbin/init directly), and bump the Leap
  snappy repository from openSUSE_Leap_15.6 to openSUSE_Leap_16.0 to
  match the rolled base image.

Bump geekyeggo/delete-artifact from v1 to v6 in the cleanup job; v1 used
the legacy artifact API and failed with 'Failed to list artifacts;
status code 404' against upload-artifact@v4.