### PR TITLE
Include the LLVM tools in the snap

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -43,6 +43,7 @@ parts:
       sed -i 's#<CRAFT_ARCH_TRIPLET>#$CRAFT_ARCH_TRIPLET#' $ENV_SH
     stage-packages:
       - clang
+      - llvm
       - cmake
       - curl
       - git


### PR DESCRIPTION
Flutter's native assets build looks for llvm-ar alongside clang (in /usr/lib/llvm-14/bin), but the clang package alone does not provide it. Stage the llvm package so llvm-ar and the other LLVM tools are available.

Fixes: https://github.com/canonical/flutter-snap/issues/115