### PR TITLE
Default to the stable Flutter channel

### DIFF
--- a/flutter.sh
+++ b/flutter.sh
@@ -33,7 +33,7 @@ download_flutter () {
 
 # Download stable via git
 download_flutter_git () {
-    git clone https://github.com/flutter/flutter.git -b master $SNAP_USER_COMMON/flutter
+    git clone https://github.com/flutter/flutter.git -b stable $SNAP_USER_COMMON/flutter
 }
 
 if [ "$1" == "version" ]; then


### PR DESCRIPTION
The SDK was cloned from the master branch, so the snap tracked the
master channel instead of stable. Clone the stable branch so new
installs default to the stable channel.

Fixes: https://github.com/canonical/flutter-snap/issues/114