### PR TITLE
Don't force software rendering

### DIFF
--- a/env.sh
+++ b/env.sh
@@ -40,7 +40,6 @@ for d in ${CLANG_SEARCH_DIRS//:/$IFS}; do
 done
 SNAP_DRIVERS_PATH="$SNAP_DRIVERS_PATH:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET/dri"
 export LIBGL_DRIVERS_PATH=$HOST_DRIVERS_PATH:$SNAP_DRIVERS_PATH:$LIBGL_DRIVERS_PATH
-export LIBGL_ALWAYS_SOFTWARE=1
 
 # if any gdk-pixbuf variables are already set (e.g. from the VS Code snap), override them
 if [ ! -z $GDK_PIXBUF_MODULE_FILE ] || [ ! -z $GDK_PIXBUF_MODULEDIR ]


### PR DESCRIPTION
env.sh unconditionally set LIBGL_ALWAYS_SOFTWARE=1, forcing Mesa to use the CPU (llvmpipe) renderer for the Flutter tools and for apps launched via 'flutter run'. This was a workaround for GL context creation failures (e.g. #57, #93) caused by the snap's Mesa/glibc mismatch with the host's GPU drivers, but it also disables hardware acceleration and conflicts with the LIBGL_DRIVERS_PATH logic that prefers host drivers.

Now that the snap is built on core22 (glibc 2.35) and locates the host's DRI drivers, drop the forced setting so hardware rendering is used by default. Users who still need software rendering can set LIBGL_ALWAYS_SOFTWARE=1 in their own environment.