### PR TITLE
CI: build and test on arm64

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,7 +9,16 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            runs-on: ubuntu-latest
+          - arch: arm64
+            # TODO: switch to ubuntu-26.04-arm once it is out of public preview
+            runs-on: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runs-on }}
     steps:
       - name: Git checkout
         uses: actions/checkout@v2
@@ -19,19 +28,19 @@ jobs:
       - name: Upload Flutter snap
         uses: actions/upload-artifact@v4
         with:
-          name: snap
+          name: snap-${{ matrix.arch }}
           path: ${{ steps.snapcraft.outputs.snap }}
-    outputs:
-      snap: ${{ steps.snapcraft.outputs.snap }}
 
   test:
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runs-on }}
     strategy:
       fail-fast: false
       # few at a time to possibly reduce conflicts due to docker host mounts
       max-parallel: 3
       matrix:
+        arch:
+          - amd64
         image:
           - debian-stable
           - fedora-42
@@ -41,6 +50,17 @@ jobs:
           - ubuntu-24.04
           - ubuntu-25.10
           - ubuntu-26.04
+        include:
+          - arch: amd64
+            runs-on: ubuntu-latest
+          # A single ARM test is enough to catch arch-specific regressions.
+          # The ubuntu-26.04-arm runner is still in public preview, so run the
+          # ubuntu-26.04 image on a 24.04 runner for now.
+          # TODO: switch to the ubuntu-26.04-arm runner once it is out of
+          # public preview.
+          - arch: arm64
+            image: ubuntu-26.04
+            runs-on: ubuntu-24.04-arm
     steps:
       - name: Git checkout
         uses: actions/checkout@v2
@@ -49,9 +69,9 @@ jobs:
       - name: Download Flutter snap
         uses: actions/download-artifact@v4
         with:
-          name: snap
+          name: snap-${{ matrix.arch }}
       - name: Install Flutter snap
-        run: sudo ./.github/scripts/install-flutter.sh --docker --dangerous ${{ needs.build.outputs.snap }}
+        run: sudo ./.github/scripts/install-flutter.sh --docker --dangerous "$(ls *.snap)"
       - name: Build Flutter app
         run: sudo ./.github/scripts/build-app.sh ${{ github.workspace }}/test/flutter_app
       - name: Run Flutter app
@@ -66,4 +86,6 @@ jobs:
       - name: Delete Flutter snap
         uses: geekyeggo/delete-artifact@v6
         with:
-          name: snap
+          name: |
+            snap-amd64
+            snap-arm64

--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -7,12 +7,14 @@ on:
 
 jobs:
   candidate:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runs-on }}
     strategy:
       fail-fast: false
       # few at a time to possibly reduce conflicts due to docker host mounts
       max-parallel: 3
       matrix:
+        arch:
+          - amd64
         image:
           - debian-stable
           - fedora-42
@@ -22,6 +24,17 @@ jobs:
           - ubuntu-24.04
           - ubuntu-25.10
           - ubuntu-26.04
+        include:
+          - arch: amd64
+            runs-on: ubuntu-latest
+          # A single ARM test is enough to catch arch-specific regressions.
+          # The ubuntu-26.04-arm runner is still in public preview, so run the
+          # ubuntu-26.04 image on a 24.04 runner for now.
+          # TODO: switch to the ubuntu-26.04-arm runner once it is out of
+          # public preview.
+          - arch: arm64
+            image: ubuntu-26.04
+            runs-on: ubuntu-24.04-arm
     steps:
       - name: Git checkout
         uses: actions/checkout@v2

--- a/flutter.sh
+++ b/flutter.sh
@@ -71,7 +71,10 @@ fi
 if [ ! -d "$SNAP_USER_COMMON/flutter/.git" ]; then
     echo "Initializing Flutter"
     init_failed=
-    if [ "$CRAFT_ARCH_TRIPLET_BUILD_FOR" == "aarch64-linux-gnu" ]; then
+    # Flutter only publishes prebuilt SDK tarballs for x86_64, so fetch the SDK
+    # via git on other architectures (e.g. arm64). Detect the running
+    # architecture at runtime rather than relying on build-time variables.
+    if [ "$(uname -m)" == "aarch64" ]; then
         download_flutter_git || init_failed=1
     else
         download_flutter || init_failed=1


### PR DESCRIPTION
Add arm64 coverage to the CI and daily workflows so the snap is built and exercised on ARM as well as x86_64. Both jobs now run on a per-arch matrix, using GitHub's ubuntu-24.04-arm runners for arm64.

Use ubuntu-24.04-arm rather than the newer ubuntu-26.04-arm as the latter is still in public preview; a TODO notes switching once it is generally available.

Fixes https://github.com/canonical/flutter-snap/issues/86