### PR TITLE
Harden shell scripts and add shellcheck lint job

### DIFF
--- a/.github/scripts/build-app.sh
+++ b/.github/scripts/build-app.sh
@@ -4,7 +4,7 @@ set -e
 
 WORKSPACE=${1:?"Pass workspace arg"}
 
-docker cp $WORKSPACE snapc:/workspace
+docker cp "$WORKSPACE" snapc:/workspace
 
 docker exec \
     -w /workspace \

--- a/.github/scripts/build-image.sh
+++ b/.github/scripts/build-image.sh
@@ -6,8 +6,8 @@ set -e
 
 DOCKERFILE=${1:?"Pass Dockerfile arg"}
 
-cd $(dirname $DOCKERFILE)
-docker build -t snapimg -f $(basename $DOCKERFILE) .
+cd "$(dirname "$DOCKERFILE")"
+docker build -t snapimg -f "$(basename "$DOCKERFILE")" .
 
 docker run \
     --name=snapc \
@@ -28,10 +28,10 @@ docker run \
 # wait for snapd to start
 TIMEOUT=600
 SLEEP=0.1
-echo -n "Waiting up to $(($TIMEOUT/10)) seconds for snapd startup "
+echo "Waiting up to $((TIMEOUT/10)) seconds for snapd startup "
 while [ "$(docker exec snapc sh -c 'systemctl status snapd.seeded >/dev/null 2>&1; echo $?')" != "0" ]; do
-    echo -n "."
-    sleep $SLEEP || exit 1
+    printf '.'
+    sleep "$SLEEP" || exit 1
     if [ "$TIMEOUT" -le "0" ]; then
         echo " Timed out!"
         echo "Container status:"
@@ -40,7 +40,7 @@ while [ "$(docker exec snapc sh -c 'systemctl status snapd.seeded >/dev/null 2>&
         docker logs snapc || true
         exit 1
     fi
-    TIMEOUT=$(($TIMEOUT-1))
+    TIMEOUT=$((TIMEOUT-1))
 done
 echo " done"
 

--- a/.github/scripts/install-flutter.sh
+++ b/.github/scripts/install-flutter.sh
@@ -21,15 +21,17 @@ while [ $# -gt 0 ]; do
     shift
 done
 
-if [ $DOCKER -eq 1 ]; then
+if [ "$DOCKER" -eq 1 ]; then
     RUNNER="docker exec snapc"
 
     # copy if it's a .snap file
-    if [ "$(basename $SNAP .snap)" != "$SNAP" ]; then
-        docker cp $SNAP snapc:$SNAP
+    if [ "$(basename "$SNAP" .snap)" != "$SNAP" ]; then
+        docker cp "$SNAP" "snapc:$SNAP"
     fi
 fi
 
-$RUNNER snap install $ARGS $SNAP
+# $RUNNER and $ARGS are deliberately word-split into separate arguments.
+# shellcheck disable=SC2086
+$RUNNER snap install $ARGS "$SNAP"
 $RUNNER flutter config --enable-linux-desktop
 $RUNNER flutter doctor -v

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,6 +8,14 @@ on:
   workflow_dispatch:
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Git checkout
+        uses: actions/checkout@v4
+      - name: Run shellcheck
+        run: shellcheck -x *.sh .github/scripts/*.sh
+
   build:
     strategy:
       fail-fast: false
@@ -21,7 +29,7 @@ jobs:
     runs-on: ${{ matrix.runs-on }}
     steps:
       - name: Git checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Build Flutter snap
         uses: snapcore/action-build@v1
         id: snapcraft
@@ -63,7 +71,7 @@ jobs:
             runs-on: ubuntu-24.04-arm
     steps:
       - name: Git checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Build image
         run: sudo ./.github/scripts/build-image.sh ./.github/docker/Dockerfile.${{ matrix.image }}
       - name: Download Flutter snap

--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -37,7 +37,7 @@ jobs:
             runs-on: ubuntu-24.04-arm
     steps:
       - name: Git checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Build image
         run: sudo ./.github/scripts/build-image.sh ./.github/docker/Dockerfile.${{ matrix.image }}
       - name: Install Flutter snap

--- a/check-deps.sh
+++ b/check-deps.sh
@@ -28,7 +28,9 @@ check_flutter_linux_deps () {
     # Identify the distribution to suggest an install command.
     local id="" like=""
     if [ -r /etc/os-release ]; then
+        # shellcheck source=/dev/null
         id=$(. /etc/os-release 2>/dev/null && echo "$ID")
+        # shellcheck source=/dev/null
         like=$(. /etc/os-release 2>/dev/null && echo "$ID_LIKE")
     fi
 

--- a/dart.sh
+++ b/dart.sh
@@ -1,20 +1,23 @@
 #!/bin/bash
 
-SCRIPT_DIR=`dirname $0`
-. $SCRIPT_DIR/env.sh
+set -e
 
-DART=$SNAP_USER_COMMON/flutter/bin/dart
+SCRIPT_DIR=$(dirname "$0")
+# shellcheck source=env.sh
+. "$SCRIPT_DIR/env.sh"
+
+DART="$SNAP_USER_COMMON/flutter/bin/dart"
 
 if [ ! -d "$SNAP_USER_COMMON/flutter/.git" ]; then
-    echo "Flutter not initialized, please run the flutter command once"
-    exit
+    echo "Flutter not initialized, please run the flutter command once" >&2
+    exit 1
 fi
 
-if [ ! -x $DART ]; then
-    echo "Could not find working copy of Dart"
-    exit
+if [ ! -x "$DART" ]; then
+    echo "Could not find working copy of Dart" >&2
+    exit 1
 fi
 
 # Always copy over the bootstrap script in case of changes
-cp $SCRIPT_DIR/env.sh $SNAP_USER_COMMON/flutter/bin/internal/bootstrap.sh
-$DART "$@"
+cp "$SCRIPT_DIR/env.sh" "$SNAP_USER_COMMON/flutter/bin/internal/bootstrap.sh"
+"$DART" "$@"

--- a/flutter.sh
+++ b/flutter.sh
@@ -2,33 +2,34 @@
 
 set -e
 
-SCRIPT_DIR=`dirname $0`
-. $SCRIPT_DIR/env.sh
+SCRIPT_DIR=$(dirname "$0")
+# shellcheck source=env.sh
+. "$SCRIPT_DIR/env.sh"
 
-FLUTTER=$SNAP_USER_COMMON/flutter/bin/flutter
+FLUTTER="$SNAP_USER_COMMON/flutter/bin/flutter"
 
 reset_install () {
   echo "Resetting flutter repository"
-  rm -rf $SNAP_USER_COMMON/flutter
+  rm -rf "$SNAP_USER_COMMON/flutter"
   download_flutter
 }
 
 # Download stable via tarball
 download_flutter () {
   # Determine URL for latest stable release
-  if [ -z $FLUTTER_STORAGE_BASE_URL ]; then
+  if [ -z "$FLUTTER_STORAGE_BASE_URL" ]; then
     export FLUTTER_STORAGE_BASE_URL=https://storage.googleapis.com
   fi
-  mkdir -p $SNAP_USER_COMMON
-  cd $SNAP_USER_COMMON
-  if ! curl -fSL -o releases_linux.json $FLUTTER_STORAGE_BASE_URL/flutter_infra_release/releases/releases_linux.json; then
+  mkdir -p "$SNAP_USER_COMMON"
+  cd "$SNAP_USER_COMMON"
+  if ! curl -fSL -o releases_linux.json "$FLUTTER_STORAGE_BASE_URL/flutter_infra_release/releases/releases_linux.json"; then
     echo "Failed to download the list of Flutter releases" >&2
     cd ~-
     return 1
   fi
-  base_url=$(cat releases_linux.json | jq -r '.base_url')
-  stable=$(cat releases_linux.json | jq -r '.current_release' | jq '.stable')
-  archive=$(cat releases_linux.json | jq -r --arg stable "$stable" '[.releases[] | select(.hash=='$stable')][0].archive')
+  base_url=$(jq -r '.base_url' releases_linux.json)
+  stable=$(jq -r '.current_release' releases_linux.json | jq '.stable')
+  archive=$(jq -r --arg stable "$stable" '[.releases[] | select(.hash=='"$stable"')][0].archive' releases_linux.json)
   if [ -z "$base_url" ] || [ -z "$archive" ] || [ "$archive" == "null" ]; then
     echo "Failed to determine the latest Flutter release" >&2
     cd ~-
@@ -36,7 +37,7 @@ download_flutter () {
   fi
   url=$base_url/$archive
   echo "Downloading $url"
-  if ! curl -fSL -o latest_stable.tar.xz --user-agent 'Flutter SDK Snap' $url; then
+  if ! curl -fSL -o latest_stable.tar.xz --user-agent 'Flutter SDK Snap' "$url"; then
     echo "Failed to download the Flutter SDK" >&2
     cd ~-
     return 1
@@ -52,7 +53,7 @@ download_flutter () {
 
 # Download stable via git
 download_flutter_git () {
-    if ! git clone https://github.com/flutter/flutter.git -b stable $SNAP_USER_COMMON/flutter; then
+    if ! git clone https://github.com/flutter/flutter.git -b stable "$SNAP_USER_COMMON/flutter"; then
       echo "Failed to clone the Flutter repository" >&2
       return 1
     fi
@@ -81,7 +82,7 @@ if [ ! -d "$SNAP_USER_COMMON/flutter/.git" ]; then
     fi
     if [ -z "$init_failed" ] && [ -x "$FLUTTER" ]; then
       echo "Flutter initialized"
-      $FLUTTER --version || true
+      "$FLUTTER" --version || true
       if [ "$#" -eq 0 ]; then
         exit
       fi
@@ -94,7 +95,7 @@ if [ ! -d "$SNAP_USER_COMMON/flutter/.git" ]; then
     fi
 fi
 
-if [ ! -x $FLUTTER ]; then
+if [ ! -x "$FLUTTER" ]; then
     echo "Could not find working copy of Flutter" >&2
     exit 1
 fi
@@ -105,23 +106,24 @@ case "$1" in
   build) if [ "$2" == "linux" ]; then NEEDS_LINUX_TOOLCHAIN=1; fi ;;
 esac
 if [ "$NEEDS_LINUX_TOOLCHAIN" == "1" ]; then
-  . $SCRIPT_DIR/check-deps.sh
+  # shellcheck source=check-deps.sh
+  . "$SCRIPT_DIR/check-deps.sh"
   check_flutter_linux_deps || true
 fi
 
 if [ "$1" == "sdk-path" ]; then
-  echo $SNAP_USER_COMMON/flutter
+  echo "$SNAP_USER_COMMON/flutter"
 elif [ "$1" == "upgrade" ]; then
   # Remove the bootstrap in case we're upgrading from stable to dev/master
-  rm -f $SNAP_USER_COMMON/flutter/bin/internal/bootstrap.sh
+  rm -f "$SNAP_USER_COMMON/flutter/bin/internal/bootstrap.sh"
   # Always restore the bootstrap script afterwards, even if the upgrade fails,
   # so we don't leave the SDK without it; propagate Flutter's exit status.
   status=0
-  $FLUTTER "$@" || status=$?
-  cp $SCRIPT_DIR/env.sh $SNAP_USER_COMMON/flutter/bin/internal/bootstrap.sh
-  exit $status
+  "$FLUTTER" "$@" || status=$?
+  cp "$SCRIPT_DIR/env.sh" "$SNAP_USER_COMMON/flutter/bin/internal/bootstrap.sh"
+  exit "$status"
 else
   # Always copy over the bootstrap script in case of changes
-  cp $SCRIPT_DIR/env.sh $SNAP_USER_COMMON/flutter/bin/internal/bootstrap.sh
-  $FLUTTER "$@"
+  cp "$SCRIPT_DIR/env.sh" "$SNAP_USER_COMMON/flutter/bin/internal/bootstrap.sh"
+  "$FLUTTER" "$@"
 fi


### PR DESCRIPTION
Bring dart.sh in line with flutter.sh: run under 'set -e', report errors to stderr and exit non-zero when Flutter is not initialized or the Dart binary is missing (previously these exited 0, hiding failures).

Fix shellcheck findings across the runtime and CI helper scripts: quote variable expansions, replace legacy backticks with $(), drop useless uses of cat, and use POSIX-safe constructs in the /bin/sh helpers. Where word splitting is intentional (docker exec runner and install args) the behaviour is kept with a targeted shellcheck directive.

Add a shellcheck lint job to the CI workflow so these issues are caught automatically, and bump actions/checkout from the deprecated v2 to v4.