### PR TITLE
CI: hold snap auto-refresh in the test container

### DIFF
--- a/.github/scripts/build-image.sh
+++ b/.github/scripts/build-image.sh
@@ -44,6 +44,11 @@ while [ "$(docker exec snapc sh -c 'systemctl status snapd.seeded >/dev/null 2>&
 done
 echo " done"
 
+# Hold automatic refreshes so snapd does not spontaneously refresh (and
+# restart) itself during the tests, which can transiently fail with
+# "snapd rollback across the restart".
+docker exec snapc snap refresh --hold
+
 docker exec snapc snap install core --edge
 
 docker exec snapc mount -o rw,nosuid,nodev,noexec,relatime securityfs -t securityfs /sys/kernel/security || true


### PR DESCRIPTION
Installing a snap can make snapd refresh and restart itself, which occasionally fails with "snapd rollback across the restart" and breaks the test job. A background auto-refresh of snapd can trigger the same restart at any point during the run.

Hold automatic refreshes with "snap refresh --hold" once snapd is ready, so snapd does not spontaneously refresh itself while the tests run.